### PR TITLE
Remove use of class properties since they are deprecated as of python 3.11 and will be removed in python 3.13

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -13,7 +13,6 @@ class Config(ABC):
         pass
 
     @classmethod
-    @property
     @abstractmethod
     def schema_path(cls) -> str:
         pass
@@ -30,7 +29,7 @@ class Config(ABC):
             cls: Object with type equal to the calling class (whicch will be a
                 descendent of this class)
         """
-        config_schema = io_utils.read_json(cls.schema_path)
+        config_schema = io_utils.read_json(cls.schema_path())
         config_kwargs = io_utils.read_yaml(project_path)
         jsonschema.validate(instance=config_kwargs, schema=config_schema)
         return cls(**config_kwargs)

--- a/core/experiment_config.py
+++ b/core/experiment_config.py
@@ -23,7 +23,6 @@ class ExperimentConfig(Config):
     MAX_NUM_MONTHS = 3600
 
     @classmethod
-    @property
     def schema_path(cls) -> str:
         return "rent_buy_invest/configs/schemas/experiment-config-schema.json"
 

--- a/core/house_config.py
+++ b/core/house_config.py
@@ -51,7 +51,6 @@ class HouseConfig(Config):
     MAX_UPFRONT_ONE_TIME_COST_AS_FRACTION_OF_SALE_PRICE = 0.5
 
     @classmethod
-    @property
     def schema_path(cls) -> str:
         return "rent_buy_invest/configs/schemas/house-config-schema.json"
 

--- a/core/market_config.py
+++ b/core/market_config.py
@@ -22,7 +22,6 @@ class MarketConfig(Config):
     MAX_MARKET_RATE_OF_RETURN = 0.5
 
     @classmethod
-    @property
     def schema_path(cls) -> str:
         return "rent_buy_invest/configs/schemas/market-config-schema.json"
 

--- a/core/rent_config.py
+++ b/core/rent_config.py
@@ -22,9 +22,7 @@ class RentConfig(Config):
     MAX_ANNUAL_RENT_INFLATION_RATE = 1.0
     MAX_SECURITY_DEPOSIT_AS_FRACTION_OF_RENT = 6
 
-    # TODO class properties are deprecated in python 3.11 and won't be supported in python 3.13
     @classmethod
-    @property
     def schema_path(cls) -> str:
         return "rent_buy_invest/configs/schemas/rent-config-schema.json"
 


### PR DESCRIPTION
Remove use of class properties since they are deprecated as of python 3.11 and will be removed in python 3.13